### PR TITLE
feat: align tools with Fellow MCP contract

### DIFF
--- a/scripts/live-check.mjs
+++ b/scripts/live-check.mjs
@@ -122,19 +122,21 @@ async function main() {
     const tools = await client.listTools();
     console.log('Tools:', tools.tools.map((tool) => tool.name).join(', '));
 
-    const me = await client.callTool({ name: 'get_me', arguments: {} });
+    const me = await client.callTool({ name: 'getMe', arguments: {} });
     console.log('Authenticated user:', me.structuredContent?.name ?? me.structuredContent);
 
     const notesResponse = await client.callTool({
-      name: 'list_notes',
-      arguments: { page_size: 3, max_pages: 1 },
+      name: 'listNotes',
+      arguments: { pagination: { page_size: 3 } },
     });
-    console.log('Fetched notes count:', notesResponse.structuredContent?.count);
+    const noteCollection =
+      notesResponse.structuredContent?.notes?.data ?? notesResponse.structuredContent?.data ?? [];
+    console.log('Fetched notes count:', Array.isArray(noteCollection) ? noteCollection.length : 0);
 
     const templates = await client.listResourceTemplates();
     console.log('Resource templates:', templates.resourceTemplates.map((tpl) => tpl.name).join(', '));
 
-    const firstNote = notesResponse.structuredContent?.notes?.[0];
+    const firstNote = Array.isArray(noteCollection) ? noteCollection[0] : undefined;
     const firstNoteId = firstNote?.id ?? firstNote?.guid;
     if (firstNoteId) {
       try {

--- a/server.ts
+++ b/server.ts
@@ -42,155 +42,279 @@ export async function call<T>(cfg: { method: 'get' | 'post'; url: string; data?:
 
 export const server = new McpServer({ name: 'fellow-mcp', version: '1.0.0' });
 
-export const getMeInputSchema = {};
+const paginationInput = z
+  .object({
+    cursor: z.union([z.string(), z.null()]).optional(),
+    page_size: z.number().int().min(1).max(50).default(20),
+  })
+  .strict();
 
-export const listNotesInputSchema = {
-  include_content_markdown: z.boolean().default(false),
-  include_event_attendees: z.boolean().default(false),
-  filters: z
-    .object({
-      event_guid: z.string().optional(),
-      title: z.string().optional(),
-      channel_id: z.string().optional(),
-      created_at_start: z.string().optional(),
-      created_at_end: z.string().optional(),
-      updated_at_start: z.string().optional(),
-      updated_at_end: z.string().optional(),
-    })
-    .partial()
-    .optional(),
-  page_size: z.number().int().min(1).max(50).default(20),
-  max_pages: z.number().int().min(1).max(20).default(3),
-};
+const sharedFilters = z
+  .object({
+    event_guid: z.string().optional(),
+    created_at_start: z.string().optional(),
+    created_at_end: z.string().optional(),
+    updated_at_start: z.string().optional(),
+    updated_at_end: z.string().optional(),
+    title: z.string().optional(),
+    channel_id: z.string().optional(),
+  })
+  .strict();
 
-export const getNoteInputSchema = {
-  note_id: z.string(),
-};
+export const listNotesInputSchema = z
+  .object({
+    filters: sharedFilters.optional(),
+    include: z
+      .object({
+        content_markdown: z.boolean().optional(),
+        event_attendees: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    pagination: paginationInput.optional(),
+  })
+  .strict();
 
-export const listRecordingsInputSchema = {
-  include_transcript: z.boolean().default(false),
-  filters: z
-    .object({
-      event_guid: z.string().optional(),
-      title: z.string().optional(),
-      channel_id: z.string().optional(),
-      created_at_start: z.string().optional(),
-      created_at_end: z.string().optional(),
-      updated_at_start: z.string().optional(),
-      updated_at_end: z.string().optional(),
-    })
-    .partial()
-    .optional(),
-  page_size: z.number().int().min(1).max(50).default(20),
-  max_pages: z.number().int().min(1).max(20).default(2),
-};
+export const getNoteInputSchema = z
+  .object({
+    note_id: z.string(),
+  })
+  .strict();
 
-async function fetchNoteById(
-  noteId: string,
-  options: { includeContentMarkdown?: boolean } = {}
-): Promise<any> {
-  const body: Record<string, unknown> = {
-    filters: { ids: [noteId] },
-    pagination: { page_size: 1 },
-  };
+export const listRecordingsInputSchema = z
+  .object({
+    filters: sharedFilters.optional(),
+    include: z
+      .object({
+        transcript: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    pagination: paginationInput.optional(),
+  })
+  .strict();
 
-  if (options.includeContentMarkdown) {
-    body.include = { content_markdown: true };
-  }
+export const getRecordingInputSchema = z
+  .object({
+    recording_id: z.string(),
+  })
+  .strict();
 
-  const payload = await call<any>({ method: 'post', url: '/notes', data: body });
-  const notes = payload?.notes?.data ?? payload?.data ?? [];
-  const note = notes.find((n: any) => n?.id === noteId) ?? notes[0];
-  if (!note) {
+const emptyInputSchema = z.object({}).strict();
+
+export const paginationJsonSchema = {
+  type: 'object',
+  properties: {
+    cursor: { type: ['string', 'null'] },
+    page_size: { type: 'integer', minimum: 1, maximum: 50, default: 20 },
+  },
+  additionalProperties: false,
+} as const;
+
+export const sharedFiltersJsonSchema = {
+  type: 'object',
+  properties: {
+    event_guid: { type: 'string' },
+    created_at_start: { type: 'string' },
+    created_at_end: { type: 'string' },
+    updated_at_start: { type: 'string' },
+    updated_at_end: { type: 'string' },
+    title: { type: 'string' },
+    channel_id: { type: 'string' },
+  },
+  additionalProperties: false,
+} as const;
+
+export const listNotesJsonSchema = {
+  type: 'object',
+  properties: {
+    filters: sharedFiltersJsonSchema,
+    include: {
+      type: 'object',
+      properties: {
+        content_markdown: { type: 'boolean' },
+        event_attendees: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+    pagination: paginationJsonSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+export const listRecordingsJsonSchema = {
+  type: 'object',
+  properties: {
+    filters: sharedFiltersJsonSchema,
+    include: {
+      type: 'object',
+      properties: {
+        transcript: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+    pagination: paginationJsonSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+export const getNoteJsonSchema = {
+  type: 'object',
+  properties: {
+    note_id: { type: 'string' },
+  },
+  required: ['note_id'],
+  additionalProperties: false,
+} as const;
+
+export const getRecordingJsonSchema = {
+  type: 'object',
+  properties: {
+    recording_id: { type: 'string' },
+  },
+  required: ['recording_id'],
+  additionalProperties: false,
+} as const;
+
+async function fetchNoteById(noteId: string): Promise<any> {
+  const payload = await call<any>({ method: 'get', url: `/note/${encodeURIComponent(noteId)}` });
+  const candidate = payload?.note ?? payload?.data ?? payload;
+  const note = Array.isArray(candidate) ? candidate[0] : candidate;
+  if (
+    !note ||
+    (typeof note === 'object' && !Array.isArray(note) && Object.keys(note).length === 0)
+  ) {
     throw new Error(`Note ${noteId} not found`);
   }
   return note;
 }
 
+async function fetchRecordingById(recordingId: string): Promise<any> {
+  const payload = await call<any>({ method: 'get', url: `/recording/${encodeURIComponent(recordingId)}` });
+  const candidate = payload?.recording ?? payload?.data ?? payload;
+  const recording = Array.isArray(candidate) ? candidate[0] : candidate;
+  if (
+    !recording ||
+    (typeof recording === 'object' && !Array.isArray(recording) && Object.keys(recording).length === 0)
+  ) {
+    throw new Error(`Recording ${recordingId} not found`);
+  }
+  return recording;
+}
+
+function buildNotesBody(input: z.infer<typeof listNotesInputSchema>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (input.filters) {
+    body.filters = input.filters;
+  }
+  if (input.include) {
+    const include: Record<string, boolean> = {};
+    if (input.include.content_markdown) include.content_markdown = true;
+    if (input.include.event_attendees) include.event_attendees = true;
+    if (Object.keys(include).length > 0) {
+      body.include = include;
+    }
+  }
+  if (input.pagination) {
+    body.pagination = {
+      cursor: input.pagination.cursor ?? undefined,
+      page_size: input.pagination.page_size ?? 20,
+    };
+  }
+  return body;
+}
+
+function buildRecordingsBody(input: z.infer<typeof listRecordingsInputSchema>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (input.filters) {
+    body.filters = input.filters;
+  }
+  if (input.include?.transcript) {
+    body.include = { transcript: true };
+  }
+  if (input.pagination) {
+    body.pagination = {
+      cursor: input.pagination.cursor ?? undefined,
+      page_size: input.pagination.page_size ?? 20,
+    };
+  }
+  return body;
+}
+
 // --------- Tools ---------
 
 server.registerTool(
-  'get_me',
+  'getMe',
   {
     title: 'Get authenticated user',
-    description: 'Calls GET /me to verify auth and fetch your Fellow identity',
-    inputSchema: {},
+    description: 'Calls GET /me to verify auth and fetch your Fellow identity.',
+    inputSchema: emptyInputSchema.shape,
   },
-  async () => {
+  async (input) => {
+    emptyInputSchema.parse(input ?? {});
     const me = await call<any>({ method: 'get', url: '/me' });
     return { content: [{ type: 'text', text: JSON.stringify(me, null, 2) }], structuredContent: me };
   }
 );
 
 server.registerTool(
-  'list_notes',
+  'listNotes',
   {
     title: 'List notes',
-    description: 'POST /notes with optional filters. Returns paginated notes; set max_pages to control pagination.',
-    inputSchema: listNotesInputSchema,
+    description: 'POST /notes with optional filters, includes, and pagination.',
+    inputSchema: listNotesInputSchema.shape,
   },
-  async ({ include_content_markdown, include_event_attendees, filters, page_size, max_pages }) => {
-    let cursor: string | null = null;
-    const collected: any[] = [];
-    for (let i = 0; i < max_pages; i++) {
-      const body: Record<string, unknown> = {
-        include: {
-          content_markdown: include_content_markdown,
-          event_attendees: include_event_attendees,
-        },
-        filters: filters || undefined,
-        pagination: { cursor: cursor ?? undefined, page_size },
-      };
-      const page = await call<any>({ method: 'post', url: '/notes', data: body });
-      const batch = page?.notes?.data ?? page?.data ?? [];
-      collected.push(...batch);
-      cursor = page?.notes?.page_info?.cursor ?? page?.page_info?.cursor ?? null;
-      if (!cursor) break;
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-    const out = { count: collected.length, notes: collected };
-    return { content: [{ type: 'text', text: JSON.stringify(out, null, 2) }], structuredContent: out };
+  async (rawInput) => {
+    const input = listNotesInputSchema.parse(rawInput ?? {});
+    const body = buildNotesBody(input);
+    const page = await call<any>({ method: 'post', url: '/notes', data: body });
+    return { content: [{ type: 'text', text: JSON.stringify(page, null, 2) }], structuredContent: page };
   }
 );
 
 server.registerTool(
-  'get_note',
+  'getNote',
   {
     title: 'Get a note by id',
-    description: 'GET /notes/{id}',
-    inputSchema: getNoteInputSchema,
+    description: 'GET /note/{note_id}.',
+    inputSchema: getNoteInputSchema.shape,
   },
-  async ({ note_id }) => {
-    const note = await fetchNoteById(note_id, { includeContentMarkdown: true });
+  async (rawInput) => {
+    const input = getNoteInputSchema.parse(rawInput ?? {});
+    const note = await fetchNoteById(input.note_id);
     return { content: [{ type: 'text', text: JSON.stringify(note, null, 2) }], structuredContent: note };
   }
 );
 
 server.registerTool(
-  'list_recordings',
+  'listRecordings',
   {
     title: 'List recordings',
-    description: 'POST /recordings with optional filters/transcript include; paginates like notes.',
-    inputSchema: listRecordingsInputSchema,
+    description: 'POST /recordings with optional filters, transcript include, and pagination.',
+    inputSchema: listRecordingsInputSchema.shape,
   },
-  async ({ include_transcript, filters, page_size, max_pages }) => {
-    let cursor: string | null = null;
-    const collected: any[] = [];
-    for (let i = 0; i < max_pages; i++) {
-      const body: Record<string, unknown> = {
-        include: { transcript: include_transcript },
-        filters: filters || undefined,
-        pagination: { cursor: cursor ?? undefined, page_size },
-      };
-      const page = await call<any>({ method: 'post', url: '/recordings', data: body });
-      const batch = page?.recordings?.data ?? page?.data ?? [];
-      collected.push(...batch);
-      cursor = page?.recordings?.page_info?.cursor ?? page?.page_info?.cursor ?? null;
-      if (!cursor) break;
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    }
-    const out = { count: collected.length, recordings: collected };
-    return { content: [{ type: 'text', text: JSON.stringify(out, null, 2) }], structuredContent: out };
+  async (rawInput) => {
+    const input = listRecordingsInputSchema.parse(rawInput ?? {});
+    const body = buildRecordingsBody(input);
+    const page = await call<any>({ method: 'post', url: '/recordings', data: body });
+    return { content: [{ type: 'text', text: JSON.stringify(page, null, 2) }], structuredContent: page };
+  }
+);
+
+server.registerTool(
+  'getRecording',
+  {
+    title: 'Get a recording by id',
+    description: 'GET /recording/{recording_id}.',
+    inputSchema: getRecordingInputSchema.shape,
+  },
+  async (rawInput) => {
+    const input = getRecordingInputSchema.parse(rawInput ?? {});
+    const recording = await fetchRecordingById(input.recording_id);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(recording, null, 2) }],
+      structuredContent: recording,
+    };
   }
 );
 
@@ -204,7 +328,7 @@ server.registerResource(
     if (!noteId) {
       throw new Error('Missing note id');
     }
-    const note = await fetchNoteById(noteId, { includeContentMarkdown: true });
+    const note = await fetchNoteById(noteId);
     const text =
       typeof note?.content_markdown === 'string' && note.content_markdown.length > 0
         ? note.content_markdown

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -118,17 +118,23 @@ describe('MCP stdio handshake', () => {
     await client.connect(clientTransport);
 
     const tools = await client.listTools();
-    expect(tools.tools.map((t) => t.name).sort()).toEqual(['get_me', 'get_note', 'list_notes', 'list_recordings']);
+    expect(tools.tools.map((t) => t.name).sort()).toEqual([
+      'getMe',
+      'getNote',
+      'getRecording',
+      'listNotes',
+      'listRecordings',
+    ]);
 
     requestMock.mockResolvedValueOnce({ data: { id: 'user-123', name: 'Test User' } });
-    const getMeResult = await client.callTool({ name: 'get_me', arguments: {} });
+    const getMeResult = await client.callTool({ name: 'getMe', arguments: {} });
     expect(getMeResult.structuredContent).toEqual({ id: 'user-123', name: 'Test User' });
 
     const templates = await client.listResourceTemplates();
     expect(templates.resourceTemplates.map((tpl) => tpl.name)).toEqual(['fellow-note']);
 
     requestMock.mockResolvedValueOnce({
-      data: { notes: { data: [{ id: 'note-1', title: 'Note One', content_markdown: '# Note One' }] } },
+      data: { note: { id: 'note-1', title: 'Note One', content_markdown: '# Note One' } },
     });
     const resource = await client.readResource({ uri: 'fellow://note/note-1' });
     expect(resource.contents[0]?.text).toContain('# Note One');

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,5 +1,4 @@
 import { beforeAll, describe, expect, test } from 'vitest';
-import { z } from 'zod';
 
 process.env.NODE_ENV = 'test';
 process.env.FELLOW_SUBDOMAIN = process.env.FELLOW_SUBDOMAIN ?? 'stub';
@@ -12,40 +11,32 @@ beforeAll(async () => {
 });
 
 describe('tool input schemas', () => {
-  test('list_notes applies defaults and accepts minimal input', () => {
-    const schema = z.object(serverModule.listNotesInputSchema);
-    const parsed = schema.parse({});
+  test('listNotes applies pagination defaults inside optional object', () => {
+    const parsed = serverModule.listNotesInputSchema.parse({ pagination: {} });
 
-    expect(parsed.include_content_markdown).toBe(false);
-    expect(parsed.include_event_attendees).toBe(false);
-    expect(parsed.page_size).toBe(20);
-    expect(parsed.max_pages).toBe(3);
-    expect(parsed.filters).toBeUndefined();
+    expect(parsed.pagination?.page_size).toBe(20);
+    expect(parsed.pagination?.cursor).toBeUndefined();
   });
 
-  test('list_notes rejects out-of-range pagination', () => {
-    const schema = z.object(serverModule.listNotesInputSchema);
-    const result = schema.safeParse({ page_size: 0, max_pages: 25 });
+  test('listNotes rejects unknown properties', () => {
+    const result = serverModule.listNotesInputSchema.safeParse({ foo: 'bar' });
 
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((issue) => issue.path[0] === 'page_size')).toBe(true);
-    }
   });
 
-  test('list_recordings mirrors pagination validation', () => {
-    const schema = z.object(serverModule.listRecordingsInputSchema);
-    const ok = schema.safeParse({});
+  test('listRecordings validates pagination bounds', () => {
+    const ok = serverModule.listRecordingsInputSchema.safeParse({ pagination: { page_size: 5 } });
     expect(ok.success).toBe(true);
 
-    const bad = schema.safeParse({ page_size: 100 });
+    const bad = serverModule.listRecordingsInputSchema.safeParse({ pagination: { page_size: 500 } });
     expect(bad.success).toBe(false);
   });
 
-  test('get_note enforces a note id', () => {
-    const schema = z.object(serverModule.getNoteInputSchema);
+  test('getNote and getRecording enforce required ids', () => {
+    expect(serverModule.getNoteInputSchema.safeParse({ note_id: 'abc-123' }).success).toBe(true);
+    expect(serverModule.getNoteInputSchema.safeParse({}).success).toBe(false);
 
-    expect(schema.safeParse({ note_id: 'abc-123' }).success).toBe(true);
-    expect(schema.safeParse({}).success).toBe(false);
+    expect(serverModule.getRecordingInputSchema.safeParse({ recording_id: 'rec-1' }).success).toBe(true);
+    expect(serverModule.getRecordingInputSchema.safeParse({}).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- align MCP tool names, schemas, and request builders with the Fellow contract
- add RESTful helpers for notes/recordings plus a getRecording tool and resource updates
- refresh live-check harness and Vitest suites to cover the new contract surface

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e61e4c7794832aa6c164535b3dc979